### PR TITLE
Missing password check when opening a wallet

### DIFF
--- a/src/js/wsui_main.js
+++ b/src/js/wsui_main.js
@@ -981,6 +981,12 @@ function handleWalletOpen(){
             return false;
         }
 
+		// validate password
+		if(!walletOpenInputPassword.value){
+			formMessageSet('load','error', `Please enter the password of the wallet!`);
+			return;
+		}
+
         let settingVals = {
             service_bin: settings.get('service_bin'),
             daemon_host: daemonHostValue,


### PR DESCRIPTION
When you create a wallet, the password is mandatory. But when you open a wallet, the password check is no longer there.