### PR TITLE
config for remote node list format

### DIFF
--- a/main.js
+++ b/main.js
@@ -248,15 +248,16 @@ function createWindow() {
 }
 
 function storeNodeList(pnodes) {
-    pnodes = pnodes || settings.get('pubnodes_data');
+    if(!pnodes) return;
+
+    if(!pnodes.length) return;
 
     let validNodes = [];
     pnodes.forEach(node => {
         let item = `${node.url}:${node.port}`;
         validNodes.push(item);
     });
-    
-    if (validNodes.length) settings.set('pubnodes_data', validNodes);
+    settings.set('pubnodes_data', validNodes);
 }
 
 function doNodeListUpdate() {
@@ -272,10 +273,11 @@ function doNodeListUpdate() {
             res.on('end', () => {
                 try {
                     var pnodes = JSON.parse(result);
-                    if(pnodes.hasOwnProperty('node')) {
-                        pnodes = pnodes.node;
+                    if(pnodes.hasOwnProperty('nodes')) {
+                        pnodes = pnodes.nodes;
                     }
                     storeNodeList(pnodes);
+                    if(result.length) settings.set('pubnodes_raw', Buffer.from(result).toString('base64'));
                     settings.set('pubnodes_last_updated', new Date().getTime());
                     settings.delete('pubnodes_tested');
                     log.debug('Public node list has been updated');

--- a/src/js/ws_config.js
+++ b/src/js/ws_config.js
@@ -33,8 +33,15 @@ config.blockExplorerUrl = 'https://explorer.turtlecoin.lol/transaction.html?hash
 // default remote node to connect to, set this to a known reliable node for 'just works' user experience
 config.remoteNodeDefaultHost = 'turtlenode.co';
 
+
 // remote node list update url, set to null if you don't have one
+// for TRTL:
+// raw list: https://raw.githubusercontent.com/turtlecoin/turtlecoin-nodes-json/master/turtlecoin-nodes.json
+// filtered: https://trtl.nodes.pub/api/getNodes
 config.remoteNodeListUpdateUrl = 'https://trtl.nodes.pub/api/getNodes';
+
+// set to false if using raw/unfiltered node list
+config.remoteNodeListFiltered = true;
 
 // fallback remote node list, in case fetching update failed, fill this with known to works remote nodes
 config.remoteNodeListFallback = [


### PR DESCRIPTION
supports both raw/unfiltered list from github and filtered/API-fied list ala trtl.nodes.pub, can be changed at build time via config: (1) as an easy switch in case trtl.nodes.pub dissapear (2) to support those forks which unlikely have similar node list api service
